### PR TITLE
Add docs.kuzzle.io site example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Inspired by the endless "awesome-*" lists out there.
 - [RedStarIT](http://www.redstarit.net/) (or [on GitHub](https://github.com/petermorlion/RedStarITSite))
 - [blue Systems Research Group](http://blue.cse.buffalo.edu/) (or [on GitHub](https://github.com/blue-systems-group/code.metalsmith-blue))
 - [Revermont.bike](http://vtt.revermont.bike/) (or [on GitHub](https://github.com/dpobel/revermont.bike))
+- [docs.kuzzle.io](http://docs.kuzzle.io/) (or [on GitHub](https://github.com/kuzzle/documentation))
 
 ### Repository
 


### PR DESCRIPTION
Add a technical documentation website sample using metalsmith.

Contains online editing feature though github, a lot of plugin usages, etc ...