### PR TITLE
add jstransformer-handlebars to the npm install

### DIFF
--- a/tutorials/js/templates.md
+++ b/tutorials/js/templates.md
@@ -6,7 +6,7 @@ This tutorial follows on from the [Introduction to Metalsmith JavaScript Interfa
 
 Lets install our first Metalsmith plugin ([metalsmith-layouts](https://github.com/superwolff/metalsmith-layouts)) and out templating engine - [Handlebars](http://handlebarsjs.com/):
 ```
-npm install --save handlebars metalsmith-layouts
+npm install --save handlebars metalsmith-layouts jstransformer-handlebars
 ```
 This will install them both.
 


### PR DESCRIPTION
If the jstransformer-handlebars is not installed, then metalsmith-layouts throws no-files-to-process error. So added it to the npm install step.